### PR TITLE
Logo image fix (macOS & iOS)

### DIFF
--- a/src/svg.ts
+++ b/src/svg.ts
@@ -179,7 +179,7 @@ export const convertSegmentsToSvgString = (qrCode: QrCode, options: Required<QrO
   if (options.isShowLogo) {
     if (!options.logoData) {
       parts.push(`
-        <use style="width: 750px; height: 750px;" 
+        <use style="width: 750px; height: 750px;" width="750" height="750" 
           fill="none" 
           fill-rule="evenodd" 
           transform="translate(${position},${position}) ${scale}" xlink:href="#vk_logo-${options.suffix}"

--- a/tests/__snapshots__/index.js.snap
+++ b/tests/__snapshots__/index.js.snap
@@ -26942,6 +26942,8 @@ exports[`Generation QR with custom logo color: toMatchXmlSnapshot 1`] = `
               \\"name\\": \\"use\\",
               \\"attributes\\": {
                 \\"style\\": \\"width: 750px; height: 750px;\\",
+                \\"width\\": \\"750\\",
+                \\"height\\": \\"750\\",
                 \\"fill\\": \\"none\\",
                 \\"fill-rule\\": \\"evenodd\\",
                 \\"transform\\": \\"translate(1046,1046) \\",
@@ -38022,6 +38024,8 @@ exports[`Generation QR with showed logo: toMatchXmlSnapshot 1`] = `
               \\"name\\": \\"use\\",
               \\"attributes\\": {
                 \\"style\\": \\"width: 750px; height: 750px;\\",
+                \\"width\\": \\"750\\",
+                \\"height\\": \\"750\\",
                 \\"fill\\": \\"none\\",
                 \\"fill-rule\\": \\"evenodd\\",
                 \\"transform\\": \\"translate(1046,1046) \\",


### PR DESCRIPTION
Logo image fix for macOS Safari & iOS mobile browsers (tested for Chrome, Safari): image has 1px size without these attrs.