### PR TITLE
ci: dependabot interval weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     allow:
       - dependency-type: "direct"
     reviewers:
@@ -14,6 +14,6 @@ updates:
     # default location of `.github/workflows`
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     reviewers:
       - "VKCOM/vk-sec"


### PR DESCRIPTION
Изменяем интервал на недельный, чтобы уменьшить кол-во PR-ов на обновление зависимостей